### PR TITLE
[requirements.txt] add Cython version constraint

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy
-cython
+cython>=0.22.0
 scipy>0.18
 coloredlogs
 enum34


### PR DESCRIPTION
While installing toppra, the error attached to the end occured on compiling cy_seidel_solverwrapper.pyx.
My Cython version was 0.20.1 (quite old...), and I found out that this problem does not occur after Cython version 0.22.0.

<details>
<summary> error message </summary>

Error compiling Cython file:

------------------------------------------------------------
...
        a_1d = None
        b_1d = None
        use_cache = False

    data = cy_solve_lp2d(v, a, b, c, low, high, active_c, use_cache, idx_map, a_1d, b_1d)
    return data.result, data.optval, data.optvar, data.active_c
                                        ^
------------------------------------------------------------

toppra/solverwrapper/cy_seidel_solverwrapper.pyx:77:41: Cannot convert 'double [2]' to Python object

Error compiling Cython file:

------------------------------------------------------------
...
        a_1d = None
        b_1d = None
        use_cache = False

    data = cy_solve_lp2d(v, a, b, c, low, high, active_c, use_cache, idx_map, a_1d, b_1d)
    return data.result, data.optval, data.optvar, data.active_c
                                                     ^
------------------------------------------------------------

toppra/solverwrapper/cy_seidel_solverwrapper.pyx:77:54: Cannot convert 'int [2]' to Python object

Error compiling Cython file:

------------------------------------------------------------
...
                # print "v={:}\n a={:}\n b={:}\n c={:}\n low={:}\n high={:}\n result={:}\n-----".format(
                    # *map(repr, map(np.asarray,
                                   # [self.v, self.a_arr[i], self.b_arr[i], self.c_arr[i], self.low_arr[i], self.high_arr[i], var])))
                # print np.asarray(self.active_c_down)
                
        return var
                 ^
------------------------------------------------------------

toppra/solverwrapper/cy_seidel_solverwrapper.pyx:624:18: Cannot convert 'double [2]' to Python object
Traceback (most recent call last):
  File "setup.py", line 51, in <module>
    ext_modules=cythonize(EXTENSIONS)
  File "/usr/lib/python2.7/dist-packages/Cython/Build/Dependencies.py", line 798, in cythonize
    cythonize_one(*args[1:])
  File "/usr/lib/python2.7/dist-packages/Cython/Build/Dependencies.py", line 915, in cythonize_one
    raise CompileError(None, pyx_file)
Cython.Compiler.Errors.CompileError: toppra/solverwrapper/cy_seidel_solverwrapper.pyx

</details>
