### PR TITLE
Undo Scaling Before Returning

### DIFF
--- a/tests/constraint/test_joint_velocity.py
+++ b/tests/constraint/test_joint_velocity.py
@@ -95,7 +95,7 @@ def test_negative_velocity():
     vlim = np.array([[-1., -2], [-2., 2]])
     with pytest.raises(AssertionError) as e_info:
         constraint = ta.constraint.JointVelocityConstraint(vlim)
-    print e_info
+    print(e_info)
     assert e_info.value.args[0][:19] == "Bad velocity limits"
 
 

--- a/toppra/algorithm/algorithm.py
+++ b/toppra/algorithm/algorithm.py
@@ -132,7 +132,8 @@ class ParameterizationAlgorithm(object):
             if delta_t < TINY:  # if a time increment is too small, skip.
                 skip_ent.append(i)
         t_grid = np.delete(t_grid, skip_ent)
-        gridpoints = np.delete(self.gridpoints, skip_ent)
+        scaling = self.gridpoints[-1] / self.path.duration
+        gridpoints = np.delete(self.gridpoints, skip_ent) / scaling
         q_grid = self.path.eval(gridpoints)
 
         traj_spline = SplineInterpolator(t_grid, q_grid, bc_type)


### PR DESCRIPTION
Scaling seems like a great way to deal with numerical stability issues. However, the returned trajectory isn't correct unless the scaling is reverted right before returning. This PR reverts scaling before returning the final trajectory.