### PR TITLE
Setup github action for linting C++ codebase

### DIFF
--- a/.circleci/README.md
+++ b/.circleci/README.md
@@ -23,3 +23,6 @@ Publish source code to venues (PyPI). NOTE: This is currently not done.
 Some tasks are done directly with Github Action. 
 
 - Linting for C++ code with clang-tidy.
+
+  Note: `cppcoreguidelines-pro-bounds-array-to-pointer-decay` leads to false reported error, thus disabled.
+

--- a/.circleci/README.md
+++ b/.circleci/README.md
@@ -1,6 +1,6 @@
 # CI
 
-We have the following CI workflows
+We have the following CI workflows in CirclCI.
 
 ## integrate
 
@@ -18,3 +18,8 @@ Check release branch for proper version.
 
 Publish source code to venues (PyPI). NOTE: This is currently not done.
 
+
+# Github Action
+Some tasks are done directly with Github Action. 
+
+- Linting for C++ code with clang-tidy.

--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,117 @@
+---
+Language:        Cpp
+# BasedOnStyle:  Google
+AccessModifierOffset: -1
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Left
+AlignOperands:   true
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: true
+AllowShortLoopsOnASingleLine: true
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: true
+AlwaysBreakTemplateDeclarations: true
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:   
+  AfterClass:      false
+  AfterControlStatement: false
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  AfterExternBlock: false
+  BeforeCatch:     false
+  BeforeElse:      false
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Attach
+BreakBeforeInheritanceComma: false
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeColon
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     80
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: true
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:   
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IncludeBlocks:   Preserve
+IncludeCategories: 
+  - Regex:           '^<ext/.*\.h>'
+    Priority:        2
+  - Regex:           '^<.*\.h>'
+    Priority:        1
+  - Regex:           '^<.*'
+    Priority:        2
+  - Regex:           '.*'
+    Priority:        3
+IncludeIsMainRegex: '([-_](test|unittest))?$'
+IndentCaseLabels: true
+IndentPPDirectives: None
+IndentWidth:     2
+IndentWrappedFunctionNames: false
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: false
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: false
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 1
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 200
+PointerAlignment: Left
+RawStringFormats: 
+  - Delimiter:       pb
+    Language:        TextProto
+    BasedOnStyle:    google
+ReflowComments:  true
+SortIncludes:    true
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 2
+SpacesInAngles:  false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Auto
+TabWidth:        8
+UseTab:          Never
+...
+

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,33 +1,23 @@
-# This is a basic workflow to help you get started with Actions
-
 name: Lint (C++, clang-tidy)
 
-# Controls when the action will run. Triggers the workflow on push or pull request
-# events but only for the master branch
 on:
   push:
     branches: [ develop ]
   pull_request:
     branches: [ develop ]
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
-  build:
-    # The type of runner that the job will run on
+  lint:
     runs-on: ubuntu-latest
 
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v2
 
-    # Runs a single command using the runners shell
     - name: Install dep
       run: |
         sudo apt-get install -y clang-tidy libeigen3-dev
 
-    # Runs a set of commands using the runners shell
     - name: Build
       run: |
         cd $GITHUB_WORKSPACE/cpp && mkdir build && cd build
@@ -37,5 +27,5 @@ jobs:
       run: |
         cd $GITHUB_WORKSPACE/cpp/build
         clang-tidy  ../src/**/*.cpp \
-        -checks=clang-analyzer-*,clang-analyzer-cplusplus*,cppcoreguidelines-*,performance-*,modernize-*,readability-*\
+        -checks=clang-analyzer-*,clang-analyzer-cplusplus*,cppcoreguidelines-*,performance-*,modernize-*,readability-,-cppcoreguidelines-pro-bounds-array-to-pointer-decay\
         -warnings-as-errors=clang-analyzer-*,clang-analyzer-cplusplus*,cppcoreguidelines-*,modernize-*

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,6 +35,7 @@ jobs:
 
     - name: lint
       run: |
-        clang-tidy  ../src/**/*.cpp -checks="clang-analyzer-*,clang-analyzer-cplusplus*,cppcoreguidelines-*,performance-*,modernize-*"
+        cd $GITHUB_WORKSPACE/cpp && mkdir build && cd build
+        clang-tidy  ../src/**/*.cpp -checks="clang-analyzer-*,clang-analyzer-cplusplus*,cppcoreguidelines-*,performance-*,modernize-*,readability-*"
 
         

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,8 +23,9 @@ jobs:
     - uses: actions/checkout@v2
 
     # Runs a single command using the runners shell
-    - name: Run a one-line script
-      run: echo Hello, world!
+    - name: Install dep
+      run: |
+        sudo apt-get install -y clang-tidy
 
     # Runs a set of commands using the runners shell
     - name: Run a multi-line script

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,6 @@
 # This is a basic workflow to help you get started with Actions
 
-name: lint (C++)
+name: Lint (C++, clang-tidy)
 
 # Controls when the action will run. Triggers the workflow on push or pull request
 # events but only for the master branch
@@ -33,9 +33,9 @@ jobs:
         cd $GITHUB_WORKSPACE/cpp && mkdir build && cd build
         cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=1 ..
 
-    - name: lint
+    - name: Lint
       run: |
         cd $GITHUB_WORKSPACE/cpp/build
-        clang-tidy  ../src/**/*.cpp -checks="clang-analyzer-*,clang-analyzer-cplusplus*,cppcoreguidelines-*,performance-*,modernize-*,readability-*"
-
-        
+        clang-tidy  ../src/**/*.cpp \
+        -checks=clang-analyzer-*,clang-analyzer-cplusplus*,cppcoreguidelines-*,performance-*,modernize-*,readability-*\
+        -warnings-as-errors=clang-analyzer-*,clang-analyzer-cplusplus*,cppcoreguidelines-*,modernize-*

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,7 +35,7 @@ jobs:
 
     - name: lint
       run: |
-        cd $GITHUB_WORKSPACE/cpp && mkdir build && cd build
+        cd $GITHUB_WORKSPACE/cpp/build
         clang-tidy  ../src/**/*.cpp -checks="clang-analyzer-*,clang-analyzer-cplusplus*,cppcoreguidelines-*,performance-*,modernize-*,readability-*"
 
         

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,12 @@ jobs:
         sudo apt-get install -y clang-tidy
 
     # Runs a set of commands using the runners shell
-    - name: Run a multi-line script
+    - name: Build
       run: |
-        echo Add other actions to build,
-        echo test, and deploy your project.
+        cd $GITHUB_WORKSPACE/cpp && mkdir build && cd build
+        cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=1 ..
+
+    - name: lint
+      run: |
+        clang-tidy ../src/**/*.cpp
+        

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,33 @@
+# This is a basic workflow to help you get started with Actions
+
+name: lint (C++)
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+on:
+  push:
+    branches: [ develop ]
+  pull_request:
+    branches: [ develop ]
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+    - uses: actions/checkout@v2
+
+    # Runs a single command using the runners shell
+    - name: Run a one-line script
+      run: echo Hello, world!
+
+    # Runs a set of commands using the runners shell
+    - name: Run a multi-line script
+      run: |
+        echo Add other actions to build,
+        echo test, and deploy your project.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
     # Runs a single command using the runners shell
     - name: Install dep
       run: |
-        sudo apt-get install -y clang-tidy
+        sudo apt-get install -y clang-tidy libeigen3-dev
 
     # Runs a set of commands using the runners shell
     - name: Build
@@ -35,5 +35,6 @@ jobs:
 
     - name: lint
       run: |
-        clang-tidy ../src/**/*.cpp
+        clang-tidy  ../src/**/*.cpp -checks="clang-analyzer-*,clang-analyzer-cplusplus*,cppcoreguidelines-*,performance-*,modernize-*"
+
         

--- a/cpp/src/CMakeLists.txt
+++ b/cpp/src/CMakeLists.txt
@@ -15,7 +15,7 @@ if (${EIGEN3_VERSION_STRING} VERSION_LESS 3.3)
   target_compile_definitions     (toppra PUBLIC ${EIGEN3_DEFINITIONS} ) 
   target_include_directories (toppra PUBLIC ${EIGEN3_INCLUDE_DIRS} ) 
 else (${EIGEN3_VERSION_STRING} VERSION_LESS 3.3) 
-  target_link_libraries(toppra PUBLIC Eigen3::Eigen3) 
+  target_link_libraries(toppra PUBLIC Eigen3::Eigen) 
 endif (${EIGEN3_VERSION_STRING} VERSION_LESS 3.3) 
 
 


### PR DESCRIPTION
Related to #84 

In this PR a linting CI job is added via github action using clang-tidy. Current the following checks are made:
```
        WARN_FLAGS=-checks="clang-analyzer-*,clang-analyzer-cplusplus*,cppcoreguidelines-*,performance-*,modernize-*,readability-*"
        ERR_FLAGS=-warnings-as-errors="clang-analyzer-*,clang-analyzer-cplusplus*,cppcoreguidelines-*,modernize-*"
        clang-tidy  ../src/**/*.cpp $CHECK_FLAGS $ERR_FLAGS
```
Reference: https://clang.llvm.org/extra/clang-tidy/