### PR TITLE
Eliminate use of deprecated method

### DIFF
--- a/tests/constraint/test_joint_acceleration.py
+++ b/tests/constraint/test_joint_acceleration.py
@@ -77,8 +77,8 @@ def test_constraint_params(accel_constraint_setup):
     N = ss.shape[0] - 1
     dof = path.dof
 
-    ps = path.evald(ss)
-    pss = path.evaldd(ss)
+    ps = path(ss, 1)
+    pss = path(ss, 2)
 
     F_actual = np.vstack((np.eye(dof), - np.eye(dof)))
     g_actual = np.hstack((alim[:, 1], - alim[:, 0]))

--- a/tests/constraint/test_joint_velocity.py
+++ b/tests/constraint/test_joint_velocity.py
@@ -56,7 +56,7 @@ class TestClass_JointVelocityConstraint(object):
         constraint_param = pc.compute_constraint_params(path, ss, 1.0)
         _, _, _, _, _, _, xlimit = constraint_param
 
-        qs = path.evald(ss)
+        qs = path(ss, 1)
         N = ss.shape[0] - 1
 
         sd = cvx.Variable()
@@ -107,7 +107,7 @@ def test_jnt_vel_varying_basic():
     gridpoints = np.linspace(0, 2, 10)
     _, _, _, _, _, _, xlimit = constraint.compute_constraint_params(path, gridpoints, 1.0)
     # constraint splines
-    qs = path.evald(gridpoints)
+    qs = path(gridpoints, 1)
     # test
     sd = cvx.Variable()
     for i in range(ss_wpts.shape[0]):

--- a/tests/constraint/test_second_order.py
+++ b/tests/constraint/test_second_order.py
@@ -59,9 +59,9 @@ def test_correctness(coefficients_functions):
         path, np.linspace(0, path.duration, 10), 1.0)
 
     # Correct params
-    q_vec = path.eval(np.linspace(0, path.duration, 10))
-    qs_vec = path.evald(np.linspace(0, path.duration, 10))
-    qss_vec = path.evaldd(np.linspace(0, path.duration, 10))
+    q_vec = path(np.linspace(0, path.duration, 10))
+    qs_vec = path(np.linspace(0, path.duration, 10), 1)
+    qss_vec = path(np.linspace(0, path.duration, 10), 2)
 
     for i in range(10):
         ai_ = A(q_vec[i]).dot(qs_vec[i])
@@ -99,9 +99,9 @@ def test_joint_torque(coefficients_functions, friction):
         path, np.linspace(0, path.duration, 10), 1.0)
 
     # Correct params
-    p_vec = path.eval(np.linspace(0, path.duration, 10))
-    ps_vec = path.evald(np.linspace(0, path.duration, 10))
-    pss_vec = path.evaldd(np.linspace(0, path.duration, 10))
+    p_vec = path(np.linspace(0, path.duration, 10))
+    ps_vec = path(np.linspace(0, path.duration, 10), 1)
+    pss_vec = path(np.linspace(0, path.duration, 10), 2)
 
     dof = 2
     F_actual = np.vstack((np.eye(dof), - np.eye(dof)))

--- a/tests/retime/robustness/test_robustness_main.py
+++ b/tests/retime/robustness/test_robustness_main.py
@@ -27,7 +27,7 @@ def test_robustness_main(request):
     parsed_problems = []
     path = pathlib.Path(__file__)
     path = path / '../problem_suite_1.yaml'
-    problem_dict = yaml.load(path.resolve().read_text())
+    problem_dict = yaml.load(path.resolve().read_text(), Loader=yaml.SafeLoader)
     for key in problem_dict:
         if len(problem_dict[key]['ss_waypoints']) == 2:
             ss_waypoints = np.linspace(problem_dict[key]['ss_waypoints'][0],

--- a/toppra/algorithm/algorithm.py
+++ b/toppra/algorithm/algorithm.py
@@ -135,7 +135,7 @@ class ParameterizationAlgorithm(object):
         t_grid = np.delete(t_grid, skip_ent)
         scaling = self.gridpoints[-1] / self.path.duration
         gridpoints = np.delete(self.gridpoints, skip_ent) / scaling
-        q_grid = self.path.eval(gridpoints)
+        q_grid = self.path(gridpoints)
 
         traj_spline = SplineInterpolator(
             t_grid,

--- a/toppra/constraint/constraint.py
+++ b/toppra/constraint/constraint.py
@@ -19,7 +19,7 @@ class DiscretizationType(Enum):
     """Enum to mark different Discretization Scheme for constraint.
 
     1. `Collocation`: smaller problem size, but lower accuracy.
-    2. `Interplation`: larger problem size, but higher accuracy.
+    2. `Interpolation`: larger problem size, but higher accuracy.
 
     In general, the difference in speed is not too large. Should use
     Interpolation if possible.

--- a/toppra/constraint/linear_joint_velocity.py
+++ b/toppra/constraint/linear_joint_velocity.py
@@ -78,7 +78,7 @@ class JointVelocityConstraintVarying(LinearConstraint):
             raise ValueError(
                 "Wrong dimension: constraint dof ({:d}) not equal to path dof ({:d})"
                 .format(self.get_dof(), path.dof))
-        qs = path.evald(gridpoints / scaling) / scaling
+        qs = path((gridpoints / scaling), 1) / scaling
         vlim_grid = np.array([self.vlim_func(s) for s in gridpoints])
         _, _, xbound_ = _create_velocity_constraint_varying(qs, vlim_grid)
         xbound = np.array(xbound_)

--- a/toppra/constraint/linear_joint_velocity.py
+++ b/toppra/constraint/linear_joint_velocity.py
@@ -12,7 +12,7 @@ class JointVelocityConstraint(LinearConstraint):
     ----------
     vlim: np.ndarray
         Shape (dof, 2). The lower and upper velocity bounds of the j-th joint
-        are given by alim[j, 0] and alim[j, 1] respectively.
+        are given by vlim[j, 0] and vlim[j, 1] respectively.
 
     """
 


### PR DESCRIPTION
Since `SplineInterpolator`'s `eval`, `evald`, `evaldd` methods are deprecated, this PR replaces them to `__call__` method.
- This change reduces the number of warnings in pytest.
- New interpolators don't need to equip with `eval`, `evald`, `evaldd` methods.
