### PR TITLE
[cpp]Add an option to configure Python version when building the Python bindings

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -14,13 +14,16 @@ option(BUILD_WITH_qpOASES "Compile the wrapper for qpOASES" OFF)
 option(BUILD_WITH_GLPK "Compile the wrapper for GLPK (GPL license)" OFF)
 # General options
 option(TOPPRA_DEBUG_ON "Set logging mode to on." OFF)
-option(PYTHON_BINDINGS "Build bindings for Python" ON)
 option(OPT_MSGPACK "Serialization using msgpack " OFF)
+# Bindings
+option(PYTHON_BINDINGS "Build bindings for Python" ON)
+option(PYTHON_VERSION "Build bindings for Python version" 3.7)
+# End of options
 
+set(PYBIND11_PYTHON_VERSION ${PYTHON_VERSION})
 include(CMakePrintHelpers)
 
 find_package (Threads)
-
 find_package (Eigen3 REQUIRED)
 message(STATUS "Found Eigen version ${EIGEN3_VERSION_STRING}")
 

--- a/cpp/src/toppra/algorithm.cpp
+++ b/cpp/src/toppra/algorithm.cpp
@@ -1,5 +1,6 @@
 #include <toppra/algorithm.hpp>
 
+#include <algorithm>
 #include <cstddef>
 #include <iostream>
 #include "toppra/toppra.hpp"
@@ -55,14 +56,16 @@ ReturnCode PathParametrizationAlgorithm::computeControllableSets(
     solver_ret = m_solver->solveStagewiseOptim(i, H, g_lower, x, x_next, solution);
 
     TOPPRA_LOG_DEBUG("down: " << solution);
-
     if (!solver_ret) {
       ret = ReturnCode::ERR_FAIL_CONTROLLABLE;
       TOPPRA_LOG_DEBUG("Fail: controllable, lower problem, idx: " << i);
       break;
     }
 
-    m_data.controllable_sets(i, 0) = solution[1];
+    // For whatever reason, sometimes the solver return negative
+    // solution despite having a set of positve bounds. This readjust
+    // if the solution is negative.
+    m_data.controllable_sets(i, 0) = std::max(0.0, solution[1]);
   }
   return ret;
 }


### PR DESCRIPTION
Changes in this PRs:
- Add an option to configure Python version when building the Python bindings
- Fix a numerical issue.

Checklists:
- [x] Update CHANGELOG.md with a single line describing this PR
