### PR TITLE
Check logger level before evaluating string in reachability_algorithm.py

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,6 +3,7 @@
 ## Unrelease
 
 ### Added
+- [python] Minor performance tweak in reachability_algorithm.py
 - [ci] Fix python2.7 dependencies
 - [python] Minor bug fixed in the SimplePath class
 - [cpp] [#129][#129] Implement constant-acceleration trajectory parametrizer

--- a/toppra/algorithm/reachabilitybased/reachability_algorithm.py
+++ b/toppra/algorithm/reachabilitybased/reachability_algorithm.py
@@ -352,11 +352,12 @@ class ReachabilityAlgorithm(ParameterizationAlgorithm):
                 x_next = xs[i] + 2 * deltas[i] * us[i]
                 x_next = max(x_next - TINY, 0.9999 * x_next)
                 xs[i + 1] = min(K[i + 1, 1], max(K[i + 1, 0], x_next))
-                logger.debug(
-                    "[Forward pass] u[{:d}] = {:f}, x[{:d}] = {:f}".format(
-                        i, us[i], i + 1, xs[i + 1]
+                if logger.isEnabledFor(logging.DEBUG):
+                    logger.debug(
+                        "[Forward pass] u[{:d}] = {:f}, x[{:d}] = {:f}".format(
+                            i, us[i], i + 1, xs[i + 1]
+                        )
                     )
-                )
                 v_vec[i] = optim_res[2:]
                 i += 1
         self.solver_wrapper.close_solver()


### PR DESCRIPTION
Changes in this PRs:
- Similar to https://github.com/hungpham2511/toppra/commit/4bfa4e8dbf86d21cfdf1701b01ebec0f934d9a5e , adds a small check before evaluating a debug string for performance reasons

Checklists:
- [x] Update HISTORY.md with a single line describing this PR
