### PR TITLE
Added pyproject.toml to fix cython bootstrapping

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,7 +113,7 @@ jobs:
       - run:
           name: Install Python API with bindings
           command: |
-            pip install invoke  # absolute minimum to run setup.py
+            pip install numpy cython invoke  # absolute minimum to run setup.py
             python -m invoke install-solvers  # require python because of circleci glitch
             pip install -e .[dev]
       - python/save-cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ commands:
             cd ~/ && git clone https://github.com/msgpack/msgpack-c.git
             cd msgpack-c && git checkout cpp-3.2.1 && cmake -DMSGPACK_CXX11=ON -DMSGPACK_BUILD_EXAMPLES=OFF -DMSGPACK_CXX_ONLY=ON .
             sudo make install
-            
+
           working_directory: ~/
       - run:
           name: Build toppra C++ API
@@ -83,7 +83,7 @@ jobs:
           path: test-results
 
       - store_artifacts:
-          path: test-results  
+          path: test-results
 
   # Test the cpp api and bindings on python3.6 The base image of this
   # job is Ubuntu 18.04, which is required to install pinocchio and
@@ -113,7 +113,7 @@ jobs:
       - run:
           name: Install Python API with bindings
           command: |
-            pip install numpy cython invoke  # absolute minimum to run setup.py
+            pip install invoke  # absolute minimum to run setup.py
             python -m invoke install-solvers  # require python because of circleci glitch
             pip install -e .[dev]
       - python/save-cache:

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,6 +3,7 @@
 ## Unrelease
 
 ### Added
+- [python] Fixed build error when cython and numpy were not pre-installed
 - [python] Allow specifying minimum nb of grid-points during automatic selection
 - [python] Minor performance tweak in reachability_algorithm.py
 - [ci] Fix python2.7 dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools", "wheel", "Cython", "numpy"]


### PR DESCRIPTION
Fixes #151. 

Verified this worked locally by first reproducing the error on `hungpham2511/toppra`, checking out this branch, then running `pip install -e .[dev]` 

Changes in this PRs:
- Adds `pyproject.toml` to install enable installing `toppra` without requiring `cython` and `numpy` pre-installed

Checklists:
- [x] Update HISTORY.md with a single line describing this PR
