### PR TITLE
Fix wrong variable for velocity

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -13,6 +13,9 @@
 - [cpp] [#143][#143] Add PathParametrizationAlgorithm::setGridpoints
 - [cpp] [#146][#146] Add constraint::CartesianVelocityNorm
 
+### Changed
+- [cpp] [#153] Fix variable mismatch in constraint::CartesianVelocityNorm
+
 ## 0.3.1 (Aug 23 2020)
 
 ### Added

--- a/cpp/src/toppra/constraint/cartesian_velocity_norm/pinocchio.hpp
+++ b/cpp/src/toppra/constraint/cartesian_velocity_norm/pinocchio.hpp
@@ -32,7 +32,7 @@ class Pinocchio : public CartesianVelocityNorm {
 
     void computeVelocity (const Vector& q, const Vector& qdot, Vector& v)
     {
-      pinocchio::forwardKinematics(m_model, m_data, q, v);
+      pinocchio::forwardKinematics(m_model, m_data, q, qdot);
       v = pinocchio::getFrameVelocity(m_model, m_data, m_frame_id, m_reference_frame).toVector();
     }
 


### PR DESCRIPTION
Fixes exploding velocity in `CartesianVelocityNorm` - the wrong variable was passed to `pinocchio::forwardKinematics`.

Checklists:
- [x] Update HISTORY.md with a single line describing this PR
