### PR TITLE
Use oldest supported numpy version during build

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- [python] Fixed build error for numpy versions <= 1.20
 
 
 ## 0.4.0 (Mar 16 2021)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,3 @@
 [build-system]
-requires = ["setuptools", "wheel", "Cython", "numpy"]
+requires = ["setuptools", "wheel", "Cython", "oldest-supported-numpy"]
+


### PR DESCRIPTION
Fixes an issue related to #151 . 

To reproduce

```sh
mkvirtualenv temp_venv --python=python3.7
pip install toppra==0.4.0 numpy==1.18.5  # or pip install -e . on upstream/master
python -c "import toppra"
```

and you should get

```sh
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/tyler/.virtual_envs/bar/lib/python3.7/site-packages/toppra/__init__.py", line 16, in <module>
    from . import constraint
  File "/home/tyler/.virtual_envs/bar/lib/python3.7/site-packages/toppra/constraint/__init__.py", line 83, in <module>
    from .linear_joint_velocity import (
  File "/home/tyler/.virtual_envs/bar/lib/python3.7/site-packages/toppra/constraint/linear_joint_velocity.py", line 3, in <module>
    from toppra._CythonUtils import (_create_velocity_constraint,
  File "toppra/_CythonUtils.pyx", line 1, in init toppra._CythonUtils
ValueError: numpy.ndarray size changed, may indicate binary incompatibility. Expected 88 from C header, got 80 from PyObject
```

Changes in this PRs:
- Fixes a build issue against older versions of numpy

Checklists:
- [x] Update HISTORY.md with a single line describing this PR


Some background on what exactly this change is can be found here, https://pypi.org/project/oldest-supported-numpy/

> The reason to use the oldest available Numpy version as a build-time dependency is because of ABI compatibility. Binaries compiled with old Numpy versions are binary compatible with newer Numpy versions, but not vice versa.

and https://github.com/scikit-learn-contrib/hdbscan/issues/457#issuecomment-773671043

> Probably, pip has always been doing this and the only reason it's breaking now is because numpy==1.20.0 is a breaking ABI change. This also means that there's nothing to "roll back", because the mere existence of a new numpy is enough to cause it.

The other way around this would be to require `numpy>=1.20` but that would rule out setups which require older versions of `numpy` (notably `tensorflow`)