### PR TITLE
Allow to build static library

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -13,9 +13,10 @@ option(BUILD_WITH_PINOCCHIO "Compile with Pinocchio library" OFF)
 option(BUILD_WITH_qpOASES "Compile the wrapper for qpOASES" OFF)
 option(BUILD_WITH_GLPK "Compile the wrapper for GLPK (GPL license)" OFF)
 # General options
-option(TOPPRA_DEBUG_ON "Set logging mode to on." OFF)
-option(TOPPRA_WARN_ON "Enable warning messages." ON)
-option(OPT_MSGPACK "Serialization using msgpack " OFF)
+option(BUILD_SHARED_LIBS "Build shared libraries" ON)
+option(TOPPRA_DEBUG_ON "Set logging mode to on" OFF)
+option(TOPPRA_WARN_ON "Enable warning messages" ON)
+option(OPT_MSGPACK "Serialization using msgpack" OFF)
 # Bindings
 option(PYTHON_BINDINGS "Build bindings for Python" ON)
 set(PYTHON_VERSION 3.7 CACHE STRING "Build bindings for Python version")

--- a/cpp/src/CMakeLists.txt
+++ b/cpp/src/CMakeLists.txt
@@ -29,6 +29,8 @@ if(BUILD_WITH_GLPK)
 endif()
 
 add_library(toppra ${SOURCE_FILES})
+set_property(TARGET toppra PROPERTY POSITION_INDEPENDENT_CODE ON)
+
 FILE(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/toppra)
 generate_export_header(toppra
   EXPORT_FILE_NAME toppra/export.hpp

--- a/cpp/src/CMakeLists.txt
+++ b/cpp/src/CMakeLists.txt
@@ -28,7 +28,7 @@ if(BUILD_WITH_GLPK)
         toppra/solver/glpk-wrapper.cpp)
 endif()
 
-add_library(toppra SHARED ${SOURCE_FILES})
+add_library(toppra ${SOURCE_FILES})
 FILE(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/toppra)
 generate_export_header(toppra
   EXPORT_FILE_NAME toppra/export.hpp


### PR DESCRIPTION
This removes the hardcoded SHARED library build, allowing users to choose between static or shared libraries, passing -DBUILD_SHARED_LIBS=True or False.
