### PR TITLE
Fixed bug in ConstAccel parametrizer where evaluating valid times can sometimes result in an exception being thrown.

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - [cpp] Minor PR to make the cpp part compiles on windows64 (msvc). Thanks @ahoarau.
+- [cpp] Fixed out of bounds issue in parametrizer::ConstAccel.
 - [python] Fix linting error that causes CI failure
 - [ci] Do integration testing in gh action instead of circle CI
 

--- a/cpp/src/toppra/parametrizer/const_accel.cpp
+++ b/cpp/src/toppra/parametrizer/const_accel.cpp
@@ -61,6 +61,13 @@ Vectors ConstAccel::eval_impl(const Vector& times, int order) const {
   Vector ss, vs, us;
   TOPPRA_LOG_DEBUG("eval_impl. order=" << order);
   bool ret = evalParams(times, ss, vs, us);
+  auto path_interval = m_path->pathInterval();
+  // Clamp all elements of ss to within the bounds of the path
+  for (std::size_t i = 0; i < ss.size(); i++) {
+    if (ss[i] > path_interval[1]) {
+      ss[i] = path_interval[1];
+    }
+  }
   assert(ret);
   switch (order) {
     case 0:

--- a/cpp/tests/test_parametrizer.cpp
+++ b/cpp/tests/test_parametrizer.cpp
@@ -100,3 +100,30 @@ TEST_F(ParametrizeConstAccel, Correctness) {
     }
   }
 }
+
+TEST(ParametrizeConstAccelNoFixture, BoundsViolation) {
+    toppra::Vectors positions = {
+      toppra::Vector::Zero(1),
+      toppra::Vector::Zero(1)
+    };
+    toppra::Vectors velocities = {
+      toppra::Vector::Zero(1),
+      toppra::Vector::Zero(1)
+    };
+
+    double PATH_LEN = 25363210.115759313106536865234375;
+
+    toppra::Vector times = toppra::Vector::LinSpaced(2, 0, PATH_LEN);
+    auto std_times = std::vector<double>(times.data(), times.data() + times.size());
+
+    auto path = toppra::PiecewisePolyPath::constructHermite(positions, velocities, std_times);
+    auto ppath = std::make_shared<toppra::PiecewisePolyPath>(path);
+
+    toppra::Vector gridpoints = toppra::Vector::LinSpaced(10, 0, PATH_LEN);
+    toppra::Vector vsquared{10};
+    vsquared << 0, 0.1, 0.2, 0.3, 0.5, 0.5, 0.3, 0.2, 0.1, 0.0;
+    auto p = toppra::parametrizer::ConstAccel(ppath, gridpoints, vsquared);
+
+    auto bound = p.pathInterval();
+    auto qs = p.eval_single(bound[1]);
+}

--- a/cpp/tests/test_parametrizer.cpp
+++ b/cpp/tests/test_parametrizer.cpp
@@ -125,5 +125,10 @@ TEST(ParametrizeConstAccelNoFixture, BoundsViolation) {
     auto p = toppra::parametrizer::ConstAccel(ppath, gridpoints, vsquared);
 
     auto bound = p.pathInterval();
-    auto qs = p.eval_single(bound[1]);
+
+    const double EPS = 1e-8;
+    EXPECT_NO_THROW(p.eval_single(bound[0]));
+    EXPECT_THROW(p.eval_single(bound[0] - EPS), std::runtime_error);
+    EXPECT_NO_THROW(p.eval_single(bound[1]));
+    EXPECT_THROW(p.eval_single(bound[1] + EPS), std::runtime_error);
 }

--- a/cpp/tests/test_parametrizer.cpp
+++ b/cpp/tests/test_parametrizer.cpp
@@ -111,7 +111,7 @@ TEST(ParametrizeConstAccelNoFixture, BoundsViolation) {
       toppra::Vector::Zero(1)
     };
 
-    double PATH_LEN = 25363210.115759313106536865234375;
+    double PATH_LEN = 3.51363644474459757560680;
 
     toppra::Vector times = toppra::Vector::LinSpaced(2, 0, PATH_LEN);
     auto std_times = std::vector<double>(times.data(), times.data() + times.size());


### PR DESCRIPTION
Fixes #184

Changes in this PR:
- Fixed bug where the `parametrizer::ConstAccel::eval_single()` can sometimes throw an out-of-bounds error, even when the time passed to it is supposedly within bounds as reported by `parametrizer::ConstAccel::pathInterval()`.

Checklists:
- [x] Update HISTORY.md with a single line describing this PR


## Description of the PR

Consider the following snippet:
```cpp
auto p = toppra::parametrizer::ConstAccel(path, gridpoints, vsquared);
auto bound = p.pathInterval();
p.eval_single(bound[1]));
```
The call to `eval_single(bound[1])` can sometimes throw an error for certain paths, even though the time `bound[1]` should be a valid evaluation time. This is due to a bug inside the `ConstAccel` parametrizer. This PR fixes this bug.

The `ConstAccel` object contains a pointer to a `GeometricPath` object called `m_path` which is injected in at construction. When `ConstAccel::eval_single()` or `ConstAccel::eval()` is called, the `ConstAccel` object translates the time passed in to a value of `s` which is subsequently used in a call to the underlying `m_path->eval()`.

As long as the time passed into `ConstAccel::eval()` in the first place is within the bounds defined by `ConstAccel::pathInterval()`, the resulting call to `m_path->eval()` should be within the bounds defined by `m_path->pathInterval()`, but due to floating point numerical errors and the way the translation works, the isn't always the case. Sometimes the resulting value of `s` passed to `m_path->eval()` can be outside the bounds defined by `m_path->pathInterval()`, and if `m_path` is of type `PiecewisePolyPath`, a `std::runtime_error` is thrown:

https://github.com/hungpham2511/toppra/blob/a70f6a217ddf20c42b62471ab52ce16884a320c1/cpp/src/toppra/geometric_path/piecewise_poly_path.cpp#L148-L153

In practice, this means it's dangerous to sample arbitrary trajectories using e.g. Eigen's `LinSpaced()` function, as sometimes this will fail when the underlying `m_path` object throws an error, especially with times which are very close to the bounds.
```cpp
auto bound = p.pathInterval();
toppra::Vector times = toppra::Vector::LinSpaced(N, bound[0], bound[1]);
p.eval(times); // <-- can sometimes fail
```

Instead, the caller must do something nasty like this:
```cpp
auto bound = p.pathInterval();
toppra::Vector times = toppra::Vector::LinSpaced(N, bound[0], bound[1]);
const double EPS = 1e-5;
times[0] += EPS;
times[N-1] -= EPS;
p.eval(times); // <-- will hopefully never fail..??!
```

Note: We assume the following assertions hold true, which appears to be the case for the `LinSpaced()` function.
```cpp
toppra::Vector times = toppra::Vector::LinSpaced(N, A, B);
assert(times[0] == A);
assert(times[N-1] == B);
```

The most important thing this PR adds is a clamp on any value before it is passed to the underlying `m_path->eval()` in order to move it within the bounds defined by `m_path->pathInterval()`. However, this means most values passed to `ConstAccel::eval()` which are outside the bounds defined by `ConstAccel::pathInterval()` get silently clamped, which is not friendly for debugging. Thus, the second thing this PR adds is a specific check that all times passed to `ConstAccel::eval()` are within the range `ConstAccel::pathInterval()` otherwise a `std::runtime_error` is thrown, which is exactly what the `PeicewisePolyPath` class does.

This PR does not address any issue which might arise from the caller doing something like the following, either inadvertently or not.
```cpp
auto p = toppra::parametrizer::ConstAccel(path, gridpoints, vsquared);
auto bound = p.pathInterval();
p.eval_single(bound[1] + SOME_TINY_VALUE));
```

This is because the caller can check for this case themselves, whereas in the bug discussed above it is not possible to do so from the outside. Also, this is an obvious violation of the `ConstAccel` object's interface.