### PR TITLE
Google Test: master -> main

### DIFF
--- a/cpp/CMakeLists.txt.in
+++ b/cpp/CMakeLists.txt.in
@@ -5,7 +5,7 @@ project(googletest-download NONE)
 include(ExternalProject)
 ExternalProject_Add(googletest
   GIT_REPOSITORY    https://github.com/google/googletest.git
-  GIT_TAG           master
+  GIT_TAG           main
   SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-src"
   BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-build"
   CONFIGURE_COMMAND ""


### PR DESCRIPTION
https://github.com/google/googletest - doesn't seem to have a master branch but a main branch now

There isn't an active issue, but noticed one of our CI jobs failing this morning and I believe this is the cause.

PS: you may want to cherry-pick back into previous tags because I believe they may also fail to build for the same reason.
