### PR TITLE
fix the f-string bug when hot_qpoases solver failed

### DIFF
--- a/toppra/algorithm/algorithm.py
+++ b/toppra/algorithm/algorithm.py
@@ -184,7 +184,7 @@ class ParameterizationAlgorithm(object):
         t0 = time.time()
         self.compute_parameterization(sd_start, sd_end)
         if self.problem_data.return_code != ParameterizationReturnCode.Ok:
-            logger.warn("Fail to parametrize path. Return code: %s", self.problem_data.return_code)
+            logger.warning("Fail to parametrize path. Return code: %s", self.problem_data.return_code)
             return None
 
         outputtraj = self.parametrizer(self.path, self.problem_data.gridpoints, self.problem_data.sd_vec)

--- a/toppra/solverwrapper/hot_qpoases_solverwrapper.py
+++ b/toppra/solverwrapper/hot_qpoases_solverwrapper.py
@@ -269,7 +269,8 @@ class hotqpOASESSolverWrapper(SolverWrapper):
             ):
                 logger.fatal(
                     f"(0, 0) satisfies all constraints => error due to numerical errors, \
-                        {self._A}, {self._lA}, {self._hA}, {self._l}, {self._h}"
+                        %s, %s, %s, %s, %s",  self._A, self._lA, self._hA, self._l, self._h
+
                 )
             else:
                 logger.debug("(0, 0) does not satisfy all constraints.")

--- a/toppra/solverwrapper/hot_qpoases_solverwrapper.py
+++ b/toppra/solverwrapper/hot_qpoases_solverwrapper.py
@@ -268,12 +268,8 @@ class hotqpOASESSolverWrapper(SolverWrapper):
                 and np.all(0 >= self._l)
             ):
                 logger.fatal(
-                    "(0, 0) satisfies all constraints => error due to numerical errors.",
-                    self._A,
-                    self._lA,
-                    self._hA,
-                    self._l,
-                    self._h,
+                    f"(0, 0) satisfies all constraints => error due to numerical errors, \
+                        {self._A}, {self._lA}, {self._hA}, {self._l}, {self._h}"
                 )
             else:
                 logger.debug("(0, 0) does not satisfy all constraints.")

--- a/toppra/solverwrapper/hot_qpoases_solverwrapper.py
+++ b/toppra/solverwrapper/hot_qpoases_solverwrapper.py
@@ -270,7 +270,6 @@ class hotqpOASESSolverWrapper(SolverWrapper):
                 logger.fatal(
                     f"(0, 0) satisfies all constraints => error due to numerical errors, \
                         %s, %s, %s, %s, %s",  self._A, self._lA, self._hA, self._l, self._h
-
                 )
             else:
                 logger.debug("(0, 0) does not satisfy all constraints.")


### PR DESCRIPTION
This pr will fix the f-string bug for `TypeError: not all arguments converted during string formatting` and deprecation warning for `The 'warn' method is deprecated, use 'warning' instead`. I will update HISTORY.md if you agree with this pr. 
