### PR TITLE
Fix spelling mistake in documentation.

### DIFF
--- a/toppra/algorithm/reachabilitybased/time_optimal_algorithm.py
+++ b/toppra/algorithm/reachabilitybased/time_optimal_algorithm.py
@@ -40,7 +40,7 @@ class TOPPRA(ReachabilityAlgorithm):
     Notes
     -----
     In addition to the given constraints, there are additional
-    constraints on the solutions enforced by the solver-warpper.
+    constraints on the solutions enforced by the solver-wrapper.
     Therefore, different parametrizations are returned for different
     solver wrappers. However, the difference should be very small,
     especially for well-conditioned problems.


### PR DESCRIPTION
Fix minor spelling mistake in documentation. Change 'warpper' to 'wrapper'.

Fixes #

Changes in this PRs:
- 
- 

Checklists:
- [ ] Update HISTORY.md with a single line describing this PR
