### PR TITLE
chore: make C++ always define all installed symbols.

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## unreleased
+- [cpp] always define all installed symbols.
+
 ## 0.5.0 (July 08 2021)
 
 - [cpp] Minor PR to make the cpp part compiles on windows64 (msvc). Thanks @ahoarau.

--- a/cpp/src/CMakeLists.txt
+++ b/cpp/src/CMakeLists.txt
@@ -9,6 +9,8 @@ set(SOURCE_FILES
 
   toppra/solver.cpp
   toppra/solver/seidel.cpp
+  toppra/solver/qpOASES-wrapper.cpp
+  toppra/solver/glpk-wrapper.cpp
 
   toppra/geometric_path.cpp
   toppra/geometric_path/piecewise_poly_path.cpp
@@ -18,15 +20,7 @@ set(SOURCE_FILES
 
   toppra/algorithm.cpp
   toppra/algorithm/toppra.cpp
-  )
-if(BUILD_WITH_qpOASES)
-    list(APPEND SOURCE_FILES
-        toppra/solver/qpOASES-wrapper.cpp)
-endif()
-if(BUILD_WITH_GLPK)
-    list(APPEND SOURCE_FILES
-        toppra/solver/glpk-wrapper.cpp)
-endif()
+)
 
 add_library(toppra ${SOURCE_FILES})
 set_property(TARGET toppra PROPERTY POSITION_INDEPENDENT_CODE ON)

--- a/cpp/src/toppra/toppra.hpp
+++ b/cpp/src/toppra/toppra.hpp
@@ -24,6 +24,8 @@
 #define TOPPRA_LOG_WARN(X) ((void)0)
 #endif
 
+#define TOPPRA_UNUSED(x) (void)(x)
+
 // Use for checking if a quantity is very close to zero
 #define TOPPRA_NEARLY_ZERO 1e-8
 #define TOPPRA_REL_TOL 1e-6


### PR DESCRIPTION
Avoid having undefined symbols when the library is not compiled with GLPK or qpOASES support.

Checklists:
- [x] Update HISTORY.md with a single line describing this PR

After this is merge, @hungpham2511 could you make a patch release pls ?