### PR TITLE
[Feature] seidel solver(cython) solves 1D LP when possible.

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### Added
+- [python] seidelWrapper solves 1d LP instead of 2d LP when x_min == x_max and solve_1d > 0
+
 ## 0.5.2 (Nov 19 2022)
 - [cpp] always define all installed symbols.
 

--- a/tests/tests/solverwrapper/test_basic_can_linear.py
+++ b/tests/tests/solverwrapper/test_basic_can_linear.py
@@ -79,14 +79,17 @@ def basic_init_fixture(request):
     print("\n [TearDown] Finish PP Fixture")
 
 
-@pytest.mark.parametrize("solver_name", ['cvxpy', 'qpOASES', "ecos", 'hotqpOASES', 'seidel'])
-@pytest.mark.parametrize("i", [3, 10, 30])
-@pytest.mark.parametrize("H", [np.array([[1.5, 0], [0, 1.0]]), np.zeros((2, 2)), None])
-@pytest.mark.parametrize("g", [np.array([0.2, -1]), np.array([0.5, 1]), np.array([2.0, 1])])
-@pytest.mark.parametrize("x_ineq", [(0.1, 1), (0.2, 0.2), (0.4, 0.3), (np.nan, np.nan)])
+@pytest.mark.parametrize("solver_name", ['cvxpy', 'qpOASES', "ecos", 'hotqpOASES', 'seidel', 'seidel_opt'])
+@pytest.mark.parametrize("i", [3, 10, 30, 40])
+@pytest.mark.parametrize("H", [np.array([[1.5, 0], [0, 1.0]]), np.zeros((2, 2)), None, None])
+@pytest.mark.parametrize("g", [np.array([0.2, -1]), np.array([0.5, 1]), np.array([2.0, 1]), np.array([0.3, 2])])
+@pytest.mark.parametrize("x_ineq", [(0.1, 1), (0.2, 0.2), (0.4, 0.3), (np.nan, np.nan), (0.3, 0.3)])
 @pytest.mark.skipif(not FOUND_CXPY, reason="This test requires cvxpy to validate results.")
 def test_basic_correctness(basic_init_fixture, solver_name, i, H, g, x_ineq):
     """Basic test case for solver wrappers.
+
+    this test tests the behavior of seidelWrapper which solves 1D LP instead of 2D LP
+    when solve_lp1d flag is given and x_min == x_max.
 
     The input fixture `basic_init_fixture` has two constraints, one
     velocity and one acceleration. Hence, in this test, I directly
@@ -108,7 +111,10 @@ def test_basic_correctness(basic_init_fixture, solver_name, i, H, g, x_ineq):
         solver = ecosWrapper(constraints, path, path_discretization)
     elif solver_name == 'seidel' and H is None:
         from toppra.solverwrapper.cy_seidel_solverwrapper import seidelWrapper
-        solver = seidelWrapper(constraints, path, path_discretization)
+        solver = seidelWrapper(constraints, path, path_discretization, solve_lp1d=0)
+    elif solver_name == 'seidel_opt' and H is None:
+        from toppra.solverwrapper.cy_seidel_solverwrapper import seidelWrapper
+        solver = seidelWrapper(constraints, path, path_discretization, solve_lp1d=1)
     else:
         return True  # Skip all other tests
 

--- a/toppra/algorithm/reachabilitybased/reachability_algorithm.py
+++ b/toppra/algorithm/reachabilitybased/reachability_algorithm.py
@@ -121,7 +121,7 @@ class ReachabilityAlgorithm(ParameterizationAlgorithm):
             from toppra.solverwrapper.cy_seidel_solverwrapper import seidelWrapper
 
             self.solver_wrapper = seidelWrapper(
-                self.constraints, self.path, self.gridpoints
+                self.constraints, self.path, self.gridpoints, solve_lp1d=True
             )
         else:
             raise NotImplementedError(

--- a/toppra/solverwrapper/cy_seidel_solverwrapper.pyx
+++ b/toppra/solverwrapper/cy_seidel_solverwrapper.pyx
@@ -437,7 +437,7 @@ cdef class seidelWrapper:
         path_discretization: array
             The discretized path positions.
         solve_lp1d: int
-            if solve_lp1d > 0, Solve 1D LP instead of 2D LP when possible (x_min == x_max)
+            if solve_lp1d > 0, solve 1D LP instead of the full 2D LP when possible: when x_min == x_max, solve for u as the variable.
         """
         self.constraints = constraint_list
         self.path = path


### PR DESCRIPTION
Fixes:
https://github.com/hungpham2511/toppra/blob/a35f2de47087d962224ba9ffc73501c7b22ca238/toppra/solverwrapper/cy_seidel_solverwrapper.pyx#L549

Changes in this PRs:
- if solve_lp1d flag is set to > 0 and x_min == x_max, seidel solver (cython version) solves an 1D LP instead of a 2D LP.

Checklists:
- [x] Update HISTORY.md with a single line describing this PR
