### PR TITLE
Fix planning_utils.py: toppra.compute_trajectory() does not return aux data.

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,7 @@
 
 ### Added
 - [python] seidelWrapper solves 1d LP instead of 2d LP when x_min == x_max and solve_1d > 0
+- [python] Fixed planning_utils.py to follow the latest api of toppra.algorithm.ParameterizationAlgorithm
 
 ## 0.5.2 (Nov 19 2022)
 - [cpp] always define all installed symbols.

--- a/toppra/planning_utils.py
+++ b/toppra/planning_utils.py
@@ -119,7 +119,7 @@ def retime_active_joints_kinematics(
     )
     _t1 = time.time()
 
-    traj_ra, aux_traj = instance.compute_trajectory(0, 0)
+    traj_ra = instance.compute_trajectory(0, 0)
     _t2 = time.time()
     logger.debug(
         "t_setup={:.5f}ms, t_solve={:.5f}ms, t_total={:.5f}ms".format(


### PR DESCRIPTION
Fixes:
planning_utils.py does not follow the latest api of toppra.algorithm.
TOPPRA instance does not return aux data.

Changes in this PRs:
- not to receive a aux value in planning_utils.py

Checklists:
- [x] Update HISTORY.md with a single line describing this PR
