### PR TITLE
Bugfix incoherent bounds seidel lp 1d

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- [cpp]: fix: Seidel LP 1D: incoherent bounds (#244)
+- [cpp]: fix: Cannot convert from 'initializer list' to 'toppra::BoundaryCond' (#245)
+
 ## 0.6.2 (Sept 19 2023)
 
 ### Changed

--- a/cpp/src/toppra/solver/seidel-internal.hpp
+++ b/cpp/src/toppra/solver/seidel-internal.hpp
@@ -116,6 +116,14 @@ LpSol1d solve_lp1d(const RowVector2& v, const Eigen::MatrixBase<Derived>& A)
     }
   }
 
+  // In case upper bound becomes less than lower bound and their difference is not more than
+  // 2*ABS_TOLERANCE, extend both bounds to not make the problem infeasible due to numerical
+  // errors.
+  if (cur_max < cur_min && cur_min - cur_max < 2 * ABS_TOLERANCE) {
+    cur_min -= ABS_TOLERANCE;
+    cur_max += ABS_TOLERANCE;
+  }
+
   if (   cur_min - cur_max > std::max(std::abs(cur_min),std::abs(cur_max))*REL_TOLERANCE
       || cur_min == infinity
       || cur_max == -infinity) {

--- a/cpp/tests/test_cubic_spline.cpp
+++ b/cpp/tests/test_cubic_spline.cpp
@@ -76,7 +76,7 @@ Vectors CubicSpline::positions;
 Vector CubicSpline::times;
 
 TEST_F(CubicSpline, ClampedSpline) {
-  BoundaryCond bc{1, {0, 0, 0, 0, 0, 0}};
+  BoundaryCond bc{1, std::vector<value_type>{0, 0, 0, 0, 0, 0}};
   BoundaryCondFull bc_type{bc, bc};
   ConstructCubicSpline(positions, times, bc_type);
   AssertSplineKnots();
@@ -92,7 +92,7 @@ TEST_F(CubicSpline, ClampedSplineString) {
 }
 
 TEST_F(CubicSpline, NaturalSpline) {
-  BoundaryCond bc{2, {0, 0, 0, 0, 0, 0}};
+  BoundaryCond bc{2, std::vector<value_type>{0, 0, 0, 0, 0, 0}};
   BoundaryCondFull bc_type{bc, bc};
   ConstructCubicSpline(positions, times, bc_type);
   AssertSplineKnots();
@@ -100,8 +100,8 @@ TEST_F(CubicSpline, NaturalSpline) {
 }
 
 TEST_F(CubicSpline, FirstOrderBoundaryConditions) {
-  BoundaryCondFull bc_type{BoundaryCond{1, {1.25, 0, 4.12, 1.75, 7.43, 5.31}},
-                           BoundaryCond{1, {3.51, 5.32, 4.63, 0, -3.12, 3.53}}};
+  BoundaryCondFull bc_type{BoundaryCond{1, std::vector<value_type>{1.25, 0, 4.12, 1.75, 7.43, 5.31}},
+                           BoundaryCond{1, std::vector<value_type>{3.51, 5.32, 4.63, 0, -3.12, 3.53}}};
   ConstructCubicSpline(positions, times, bc_type);
   AssertSplineKnots();
   AssertSplineBoundaryConditions(bc_type);
@@ -109,8 +109,8 @@ TEST_F(CubicSpline, FirstOrderBoundaryConditions) {
 
 TEST_F(CubicSpline, SecondOrderBoundaryConditions) {
   BoundaryCondFull bc_type{
-      BoundaryCond{2, {1.52, -4.21, 7.21, 9.31, -1.53, 7.54}},
-      BoundaryCond{2, {-5.12, 8.21, 9.12, 5.12, 24.12, 9.42}}};
+      BoundaryCond{2, std::vector<value_type>{1.52, -4.21, 7.21, 9.31, -1.53, 7.54}},
+      BoundaryCond{2, std::vector<value_type>{-5.12, 8.21, 9.12, 5.12, 24.12, 9.42}}};
   ConstructCubicSpline(positions, times, bc_type);
   AssertSplineKnots();
   AssertSplineBoundaryConditions(bc_type);
@@ -118,8 +118,8 @@ TEST_F(CubicSpline, SecondOrderBoundaryConditions) {
 
 TEST_F(CubicSpline, FirstOrderAndSecondOrderBoundaryConditions) {
   BoundaryCondFull bc_type{
-      BoundaryCond{1, {1.52, -4.21, 7.21, 9.31, -1.53, 7.54}},
-      BoundaryCond{2, {-5.12, 8.21, 9.12, 5.12, 24.12, 9.42}}};
+      BoundaryCond{1, std::vector<value_type>{1.52, -4.21, 7.21, 9.31, -1.53, 7.54}},
+      BoundaryCond{2, std::vector<value_type>{-5.12, 8.21, 9.12, 5.12, 24.12, 9.42}}};
   ConstructCubicSpline(positions, times, bc_type);
   AssertSplineKnots();
   AssertSplineBoundaryConditions(bc_type);
@@ -132,8 +132,8 @@ TEST_F(CubicSpline, BadPositions) {
                                        {6.25, 8.12, 9.52, 5.21, 8.31},
                                        {7.31, 3.53, 8.41, 9.56, -3.15, 4.83}});
   BoundaryCondFull bc_type{
-      BoundaryCond{2, {1.52, -4.21, 7.21, 9.31, -1.53, 7.54}},
-      BoundaryCond{2, {-5.12, 8.21, 9.12, 5.12, 24.12, 9.42}}};
+      BoundaryCond{2, std::vector<value_type>{1.52, -4.21, 7.21, 9.31, -1.53, 7.54}},
+      BoundaryCond{2, std::vector<value_type>{-5.12, 8.21, 9.12, 5.12, 24.12, 9.42}}};
   ASSERT_THROW(ConstructCubicSpline(bad_positions, times, bc_type),
                std::runtime_error);
 
@@ -147,8 +147,8 @@ TEST_F(CubicSpline, BadPositions) {
 
 TEST_F(CubicSpline, BadTimes) {
   BoundaryCondFull bc_type{
-      BoundaryCond{2, {1.52, -4.21, 7.21, 9.31, -1.53, 7.54}},
-      BoundaryCond{2, {-5.12, 8.21, 9.12, 5.12, 24.12, 9.42}}};
+      BoundaryCond{2, std::vector<value_type>{1.52, -4.21, 7.21, 9.31, -1.53, 7.54}},
+      BoundaryCond{2, std::vector<value_type>{-5.12, 8.21, 9.12, 5.12, 24.12, 9.42}}};
   Vector bad_times(1);
   bad_times << 1;
   ASSERT_THROW(ConstructCubicSpline(positions, bad_times, bc_type),
@@ -167,8 +167,8 @@ TEST_F(CubicSpline, BadTimes) {
 
 TEST_F(CubicSpline, BadBoundaryConditions) {
   BoundaryCondFull bc_type{
-      BoundaryCond{2, {1.52, 7.21, 9.31, -1.53, 7.54}},
-      BoundaryCond{2, {-5.12, 8.21, 9.12, 5.12, 24.12, 9.42}}};
+      BoundaryCond{2, std::vector<value_type>{1.52, 7.21, 9.31, -1.53, 7.54}},
+      BoundaryCond{2, std::vector<value_type>{-5.12, 8.21, 9.12, 5.12, 24.12, 9.42}}};
   ASSERT_THROW(ConstructCubicSpline(positions, times, bc_type),
                std::runtime_error);
 
@@ -177,8 +177,8 @@ TEST_F(CubicSpline, BadBoundaryConditions) {
   ASSERT_THROW(ConstructCubicSpline(positions, times, bc_type),
                std::runtime_error);
 
-  bc_type = {BoundaryCond{3, {1.52, 7.21, 9.31, 2.52, 4.41, 5.54}},
-             BoundaryCond{3, {-5.12, 8.21, 9.12, -1.32, 3.53, 9.21}}};
+  bc_type = {BoundaryCond{3, std::vector<value_type>{1.52, 7.21, 9.31, 2.52, 4.41, 5.54}},
+             BoundaryCond{3, std::vector<value_type>{-5.12, 8.21, 9.12, -1.32, 3.53, 9.21}}};
   ASSERT_THROW(ConstructCubicSpline(positions, times, bc_type),
                std::runtime_error);
 }

--- a/cpp/tests/test_solver.cpp
+++ b/cpp/tests/test_solver.cpp
@@ -288,7 +288,6 @@ TEST(SeidelFunctions_1D, infeasible_due_to_incoherent_bounds) {
   A << seidel::TINY / 2, 1;
   sol = seidel::solve_lp1d(v, A);
   EXPECT_FALSE(sol.feasible);
-  
 }
 
 TEST(SeidelFunctions_1D, feasible_with_a_and_b_small) {
@@ -346,6 +345,25 @@ TEST(SeidelFunctions_1D, feasible_but_with_tolerated_constraint_violation) {
 
   auto sol = seidel::solve_lp1d(v, A);
   EXPECT_TRUE(sol.feasible);
+
+  {
+    // Issue #244
+    v = { -65.960772491990838, 0.0 };
+    A.resize(8, 2);
+    A <<
+     -65.9607724919908,                      -0.0151605259038078,
+      65.9607724919908,                     -0.00782362866419491,
+     0.468679477393087,                      5.6843418860808e-14,
+    -0.468679477393087,                                    -1000,
+                     0, -std::numeric_limits<double>::infinity(),
+                     0, -std::numeric_limits<double>::infinity(),
+     -65.9607724919908,                                        0,
+      65.9607724919908,                      -0.0229841545680027;
+
+    auto sol = seidel::solve_lp1d(v, A);
+    EXPECT_TRUE(sol.feasible);
+    EXPECT_NEAR(0, sol.optvar, TOPPRA_ABS_TOL);
+  }
 }
 
 TEST(SeidelFunctions, seidel_2d) {


### PR DESCRIPTION
Fixes #244 and #245 

Changes in this PRs:
- Prevent a problem becoming infeasible due to numerical errors by extending the lower and upper bounds if they are very close.
- Explicitly call std::vector constructor to avoid ambiguity when providing initializer list to BoundaryCond.

Checklists:
- [x] Update HISTORY.md with a single line describing this PR
