### PR TITLE
fix a,b,c computed in computeParams_impl

### DIFF
--- a/cpp/src/toppra/constraint/joint_torque.cpp
+++ b/cpp/src/toppra/constraint/joint_torque.cpp
@@ -48,9 +48,9 @@ void JointTorque::computeParams_impl(const GeometricPath& path,
     assert(acc.size() == ndofs);
 
     computeInverseDynamics(cfg, zero, zero, c[i]);
-    computeInverseDynamics(cfg, zero, vel, a[i]);
+    computeInverseDynamics(cfg, zero, acc, a[i]);
     a[i] -=  c[i];
-    computeInverseDynamics(cfg, vel, acc, b[i]);
+    computeInverseDynamics(cfg, vel, zero, b[i]);
     b[i] -=  c[i];
 
     if (m_frictionCoeffs.size() > 0)

--- a/cpp/src/toppra/constraint/joint_torque.cpp
+++ b/cpp/src/toppra/constraint/joint_torque.cpp
@@ -50,7 +50,7 @@ void JointTorque::computeParams_impl(const GeometricPath& path,
     computeInverseDynamics(cfg, zero, zero, c[i]);
     computeInverseDynamics(cfg, zero, acc, a[i]);
     a[i] -=  c[i];
-    computeInverseDynamics(cfg, vel, zero, b[i]);
+    computeInverseDynamics(cfg, vel, acc, b[i]);
     b[i] -=  c[i];
 
     if (m_frictionCoeffs.size() > 0)


### PR DESCRIPTION
Fixes #

Changes in this PRs:
- computeInverseDynamics(cfg, zero, vel, a[i]);
- computeInverseDynamics(cfg, vel, acc, b[i]);

Checklists:
- [ ] Modified the calculation method of Dynamics parameter a,b,c from InverseDynamic 
