### PR TITLE
Use ASSERT_NEAR for 0 comparison in test_parametrizer.cpp

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,6 @@
 # Changelog
 
+- [cpp]: fix: Update parametrizer test comparisons (#264)
 - [cpp]: fix: Seidel LP 1D: incoherent bounds (#244)
 - [cpp]: fix: Cannot convert from 'initializer list' to 'toppra::BoundaryCond' (#245)
 

--- a/cpp/tests/test_parametrizer.cpp
+++ b/cpp/tests/test_parametrizer.cpp
@@ -45,11 +45,11 @@ TEST_F(ParametrizeConstAccel, Basic) {
   auto qds = p.eval(ts, 1);
   auto qdds = p.eval(ts, 2);
   ASSERT_TRUE(p.validate());
-  ASSERT_EQ(qds[0][0], 0);
-  ASSERT_EQ(qds[0][1], 0);
+  ASSERT_NEAR(qds[0][0], 0, 1e-10);
+  ASSERT_NEAR(qds[0][1], 0, 1e-10);
 
-  ASSERT_EQ(qds[9][0], 0);
-  ASSERT_EQ(qds[9][1], 0);
+  ASSERT_NEAR(qds[9][0], 0, 1e-10);
+  ASSERT_NEAR(qds[9][1], 0, 1e-10);
 }
 
 TEST_F(ParametrizeConstAccel, Correctness) {


### PR DESCRIPTION
Fixes #264 

I'm not sure if this is paving over a more fundamental issue in interpolation or not, but very, very small rounding errors in fp arithmetic seem to be making the final time point in the basic test non-zero in some cases. I _think_ that the minute values are still ok, so we could use FP comparisons instead of exact comparisons in this test. 

Changes in this PRs:
- Use `ASSERT_NEAR` for 0 comparisons

Checklists:
- [ ] Update HISTORY.md with a single line describing this PR
