### PR TITLE
Add python3_dev and eigen as a dependency in package.xml

### DIFF
--- a/cpp/package.xml
+++ b/cpp/package.xml
@@ -13,6 +13,7 @@
  <author>Hung Pham</author>
  <author>Joseph Mirabel</author>
 
+ <build_depend>eigen</build_depend>
  <build_depend>pybind11-dev</build_depend>
 
  <buildtool_depend>ament_cmake</buildtool_depend>

--- a/cpp/package.xml
+++ b/cpp/package.xml
@@ -15,6 +15,7 @@
 
  <depend>eigen</depend>
  <build_depend>pybind11-dev</build_depend>
+ <build_depend>python3-dev</build_depend>
 
  <buildtool_depend>ament_cmake</buildtool_depend>
  <buildtool_depend>ament_cmake_python</buildtool_depend>

--- a/cpp/package.xml
+++ b/cpp/package.xml
@@ -13,7 +13,7 @@
  <author>Hung Pham</author>
  <author>Joseph Mirabel</author>
 
- <build_depend>eigen</build_depend>
+ <depend>eigen</depend>
  <build_depend>pybind11-dev</build_depend>
 
  <buildtool_depend>ament_cmake</buildtool_depend>


### PR DESCRIPTION
Changes in this PRs:
- One more fix for the ROS build farm (sorry this is going to be somewhat iterative at the start as I track the jobs) -- specifically this fixes Humble, whereas the others already seemed to have dependencies setup.

Checklists:
- [x] Update HISTORY.md with a single line describing this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added Eigen as a runtime dependency.
  * Added python3-dev as a build dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->