### PR TITLE
Fix wheel artifact upload path in CI

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 Fixes #
 
-Changes in this PRs:
+Changes in this PR:
 - 
 - 
 

--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -141,7 +141,7 @@ jobs:
         with:
           name: dist
           path: |
-            dist
+            python/dist
 
   release:
     needs: ["build-sdist", "build-wheels", "python", "cpp"]


### PR DESCRIPTION
Changes in this PR:
- noticed the tagged releases were failing CI re: uploading to pypi. I think this is another straggling issue due to the folder moving.

Checklists:
- [x] Update HISTORY.md with a single line describing this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated release artifact packaging configuration to ensure the build produces and uploads distribution files from the correct directory.

* **Documentation**
  * Fixed wording in the pull request template for correct grammar.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->