### PR TITLE
[cpp] Fix gtest target_link_libraries usage when fetching from source

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Upcoming
+
+- [cpp] Fix gtest target_link_libraries usage when fetching from source (#286)
+
 ## 0.6.7 (April 9 2026)
 
 - [cpp] Modernize googletest CMake usage (#283)

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -7,7 +7,7 @@ project(toppra
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 # Tests
-option(BUILD_TESTS "Build Gtests" ON)
+option(BUILD_TESTING "Build Gtests" ON)
 # Dynamics
 option(BUILD_WITH_PINOCCHIO "Compile with Pinocchio library" OFF)
 # Solvers
@@ -53,7 +53,7 @@ add_subdirectory(src)
 add_subdirectory(doc)
 add_subdirectory(bindings)
 
-if(BUILD_TESTS)
+if(BUILD_TESTING)
   enable_testing()
   add_subdirectory(tests)
 endif()

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -53,6 +53,11 @@ add_subdirectory(src)
 add_subdirectory(doc)
 add_subdirectory(bindings)
 
+# Backward compatibility: support legacy BUILD_TESTS for downstream scripts.
+if(DEFINED BUILD_TESTS)
+  set(BUILD_TESTING "${BUILD_TESTS}" CACHE BOOL "Build Gtests" FORCE)
+  message(DEPRECATION "BUILD_TESTS is deprecated; use BUILD_TESTING.")
+endif()
 if(BUILD_TESTING)
   enable_testing()
   add_subdirectory(tests)

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -28,7 +28,7 @@ set(TEST_SOURCES
   )
 
 add_executable(all_tests ${TEST_SOURCES})
-target_link_libraries(all_tests PUBLIC toppra GTest::gtest ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(all_tests PUBLIC toppra gtest ${CMAKE_THREAD_LIBS_INIT})
 target_include_directories(all_tests PRIVATE .)
 
 if(BUILD_WITH_PINOCCHIO)

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -34,7 +34,7 @@ set(TEST_SOURCES
   )
 
 add_executable(all_tests ${TEST_SOURCES})
-target_link_libraries(all_tests PUBLIC toppra Gtest::gtest ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(all_tests PUBLIC toppra GTest::gtest ${CMAKE_THREAD_LIBS_INIT})
 target_include_directories(all_tests PRIVATE .)
 
 if(BUILD_WITH_PINOCCHIO)

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -10,6 +10,12 @@ if(NOT GTest_FOUND)
   # For Windows: Prevent overriding the parent project's compiler/linker settings
   set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
   FetchContent_MakeAvailable(googletest)
+
+  # gtest target is non-namespaced whe built via FetchContent,
+  # so we will make an alias to correct this.
+  if(TARGET gtest AND NOT TARGET GTest::gtest)
+    add_library(GTest::gtest ALIAS gtest)
+  endif()
 endif()
 
 # Now simply link against gtest or gtest_main as needed.
@@ -28,7 +34,7 @@ set(TEST_SOURCES
   )
 
 add_executable(all_tests ${TEST_SOURCES})
-target_link_libraries(all_tests PUBLIC toppra gtest ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(all_tests PUBLIC toppra Gtest::gtest ${CMAKE_THREAD_LIBS_INIT})
 target_include_directories(all_tests PRIVATE .)
 
 if(BUILD_WITH_PINOCCHIO)


### PR DESCRIPTION
Changes in this PR:
- It seems my last PR actually caused issues when hitting the case where `googletest` has to be fetched from source instead. In other words, the ROS buildfarm builds were fixed in some operating systems, and broke on others 🤦🏻 

Checklists:
- [x] Update HISTORY.md with a single line describing this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an "Upcoming" changelog entry noting a C++ test-linking fix.

* **Bug Fixes**
  * Ensured test framework links reliably whether the dependency is provided or fetched.

* **Chores**
  * Renamed the CMake test build option and added a backward-compatible deprecation path for existing builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->