### PR TITLE
fix pinocchio 4 compatibility

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## Unreleased
+
 - [cpp] fix: pinocchio v4 compatibility
 
 ## 0.6.7 (April 9 2026)

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- [cpp] fix: pinocchio v4 compatibility
+
 ## 0.6.7 (April 9 2026)
 
 - [cpp] Modernize googletest CMake usage (#283)

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -4,8 +4,6 @@ project(toppra
   VERSION 0.6.7
   DESCRIPTION "Library computing the time-optimal path parameterization."
   LANGUAGES CXX)
-set(CMAKE_CXX_STANDARD 14)
-set(CMAKE_CXX_STANDARD_REQUIRED True)
 # Tests
 option(BUILD_TESTS "Build Gtests" ON)
 # Dynamics

--- a/cpp/tests/test_constraints.cpp
+++ b/cpp/tests/test_constraints.cpp
@@ -73,10 +73,7 @@ TEST_F(Constraint, jointTorquePinocchio) {
 
   JointTorque::Model model;
   pinocchio::buildModels::manipulator(model);
-#if PINOCCHIO_VERSION_AT_MOST(2,4,1)
-  // Work around bug solved by https://github.com/stack-of-tasks/pinocchio/pull/1155
-  model.effortLimit.setConstant(10);
-#endif
+
   Vector frictions (Vector::Constant(model.nv, 0.001));
   JointTorque constraint (model, frictions);
 

--- a/cpp/tests/test_constraints.cpp
+++ b/cpp/tests/test_constraints.cpp
@@ -4,7 +4,7 @@
 #ifdef BUILD_WITH_PINOCCHIO
 #include <toppra/constraint/joint_torque/pinocchio.hpp>
 #include <toppra/constraint/cartesian_velocity_norm/pinocchio.hpp>
-#include <pinocchio/parsers/sample-models.hpp>
+#include <pinocchio/multibody/sample-models.hpp>
 #endif
 
 #include <toppra/geometric_path.hpp>


### PR DESCRIPTION
Hi,

`pinocchio/parsers/sample-models.hpp` was a pinocchio v2 header, and it was deprecated and moved to `multibody` in pinocchio v3.
    
ref. https://github.com/stack-of-tasks/pinocchio/blob/v4.0.0/doc/_porting/porting-2-to-3.md
    
In pinocchio v4, all Pinocchio 3 deprecated headers had been removed
    
ref. https://github.com/stack-of-tasks/pinocchio/blob/v4.0.0/doc/_porting/porting-3-to-4.md


Also, I think setting `CMAKE_CXX_STANDARD` break things and should be avoided.
If there is a reason to downgrade the default standard from the compiler (eg. gcc 13 from ubuntu 24.04 has C++17), please document it.
If you fear some users compiler will default to something less than C++14, we can use modern cmake tagging for the targets, or even old school cmake to detect that at configure time.

In any case, pinocchio v4 require C++17: https://github.com/stack-of-tasks/pinocchio/blob/v4.0.0/CMakeLists.txt#L107


Checklists:
- [x] Update HISTORY.md with a single line describing this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restored compatibility with Pinocchio v4 by updating library usage and removing version-specific workarounds.

* **Chores**
  * Relaxed enforced C++ standard so builds follow CMake/toolchain defaults for greater flexibility.

* **Documentation**
  * Added an “Unreleased” entry to the project history noting the Pinocchio v4 fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->