### PR TITLE
[cpp] Fix missing cassert includes in headers

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 - [cpp] fix: pinocchio v4 compatibility
-- [cpp] Add missing cassert includes
+- [cpp] Fix missing cassert includes in headers
 
 ## 0.6.7 (April 9 2026)
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - [cpp] fix: pinocchio v4 compatibility
+- [cpp] Add missing cassert includes
 
 ## 0.6.7 (April 9 2026)
 

--- a/cpp/src/toppra/constraint/joint_torque.cpp
+++ b/cpp/src/toppra/constraint/joint_torque.cpp
@@ -1,5 +1,3 @@
-#include <cassert>
-
 #include <toppra/constraint/joint_torque.hpp>
 
 #include <toppra/geometric_path.hpp>

--- a/cpp/src/toppra/constraint/joint_torque.hpp
+++ b/cpp/src/toppra/constraint/joint_torque.hpp
@@ -1,6 +1,8 @@
 #ifndef TOPPRA_CONSTRAINT_JOINT_TORQUE_HPP
 #define TOPPRA_CONSTRAINT_JOINT_TORQUE_HPP
 
+#include <cassert>
+
 #include <toppra/constraint.hpp>
 
 namespace toppra {

--- a/cpp/src/toppra/constraint/linear_joint_velocity.cpp
+++ b/cpp/src/toppra/constraint/linear_joint_velocity.cpp
@@ -1,5 +1,3 @@
-#include <cassert>
-
 #include <toppra/constraint/linear_joint_velocity.hpp>
 
 #include <toppra/geometric_path.hpp>

--- a/cpp/src/toppra/constraint/linear_joint_velocity.hpp
+++ b/cpp/src/toppra/constraint/linear_joint_velocity.hpp
@@ -1,6 +1,8 @@
 #ifndef TOPPRA_CONSTRAINT_LINEAR_JOINT_VELOCITY_HPP
 #define TOPPRA_CONSTRAINT_LINEAR_JOINT_VELOCITY_HPP
 
+#include <cassert>
+
 #include <toppra/constraint.hpp>
 
 namespace toppra {

--- a/cpp/src/toppra/solver/glpk-wrapper.cpp
+++ b/cpp/src/toppra/solver/glpk-wrapper.cpp
@@ -4,6 +4,7 @@
 # include <glpk.h>
 #endif
 
+#include <cassert>
 #include <iostream>
 
 namespace toppra {

--- a/cpp/src/toppra/solver/qpOASES-wrapper.cpp
+++ b/cpp/src/toppra/solver/qpOASES-wrapper.cpp
@@ -1,3 +1,5 @@
+#include <cassert>
+
 #include <toppra/solver/qpOASES-wrapper.hpp>
 
 #ifdef BUILD_WITH_qpOASES


### PR DESCRIPTION
Changes in this PR:
- #280 did not catch them all, as I just learned the hard way trying some conda stuff... 
- The culprit is that some of the `cassert` includes were in the `.cpp` files when in fact they should have been up at the `.hpp` level.

Apologies for the continued tweaks, but it does take some effort to put packages like these through -- in this case -- several build/packaging workflows and discovering surprises along the way. It will stabilize over time!

Checklists:
- [x] Update HISTORY.md with a single line describing this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of constraint validation and solver checks by ensuring assertion checks are consistently available across headers and implementation files, reducing risk of missed runtime validations.

* **Documentation**
  * Added an entry to the changelog under Upcoming documenting these fixes for transparency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->